### PR TITLE
Upgrade aws-cli to 1.18.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk -v --no-cache add \
         less \
         mailcap \
         && \
-    pip install --upgrade awscli==1.16.57 s3cmd==2.0.1 python-magic && \
+    pip install --upgrade awscli==1.18.21 s3cmd==2.0.1 python-magic && \
     apk -v --purge del py-pip
 VOLUME /root/.aws
 VOLUME /project


### PR DESCRIPTION
Upgraded aws-cli

**Test steps**
**Before**

Run the following commands
```
- docker run -it --entrypoint sh karlkfi/aws-cli
- /project # export AWS_ACCESS_KEY_ID=ABC
- /project # export AWS_SECRET_ACCESS_KEY=DEF
- /project # export AWS_DEFAULT_REGION=us-east-1
- aws ec2 get-ebs-encryption-by-default
```

This gives an output that get-ebs-encryption-by-default is not a valid command.

**After**
```
- docker build -t aws-cli .
- docker run -it --entrypoint sh aws-cli:latest
- /project # export AWS_ACCESS_KEY_ID=ABC
- /project # export AWS_SECRET_ACCESS_KEY=DEF
- /project # export AWS_DEFAULT_REGION=us-east-1
- aws ec2 get-ebs-encryption-by-default
```
- get-ebs-encryption-by-default is recognised as a valid command